### PR TITLE
1.20 add set command and add null check in MobsLevelingEvents

### DIFF
--- a/src/main/java/daripher/autoleveling/command/AutoLevelingCommands.java
+++ b/src/main/java/daripher/autoleveling/command/AutoLevelingCommands.java
@@ -37,6 +37,17 @@ public class AutoLevelingCommands {
                             .executes(AutoLevelingCommands::executeGetLevelCommand)))
             .requires(AutoLevelingCommands::hasPermission);
     event.getDispatcher().register(getGlobalLevelCommand);
+    LiteralArgumentBuilder<CommandSourceStack> setGlobalLevelCommand =
+        Commands.literal("autoleveling")
+            .then(
+                Commands.literal("level")
+                    .then(
+                        Commands.literal("set")
+                            .then(
+                                Commands.argument("value", IntegerArgumentType.integer())
+                                    .executes(AutoLevelingCommands::executeSetLevelCommand))))
+            .requires(AutoLevelingCommands::hasPermission);
+    event.getDispatcher().register(setGlobalLevelCommand);
   }
 
   private static int executeAddLevelCommand(CommandContext<CommandSourceStack> ctx) {
@@ -53,6 +64,14 @@ public class AutoLevelingCommands {
     GlobalLevelingData globalLevelingData = GlobalLevelingData.get(server);
     int levelBonus = globalLevelingData.getLevelBonus();
     ctx.getSource().sendSystemMessage(Component.literal("Global level bonus is " + levelBonus));
+    return 1;
+  }
+
+  private static int executeSetLevelCommand(CommandContext<CommandSourceStack> ctx) {
+    MinecraftServer server = ctx.getSource().getServer();
+    GlobalLevelingData globalLevelingData = GlobalLevelingData.get(server);
+    Integer newLevel = ctx.getArgument("value", Integer.class);
+    globalLevelingData.setLevel(newLevel);
     return 1;
   }
 

--- a/src/main/java/daripher/autoleveling/event/MobsLevelingEvents.java
+++ b/src/main/java/daripher/autoleveling/event/MobsLevelingEvents.java
@@ -202,7 +202,7 @@ public class MobsLevelingEvents {
 
   private static Map<Attribute, AttributeModifier> getAttributeBonuses(LivingEntity entity) {
     LevelingSettings settings = getLevelingSettings(entity);
-    if (settings.attributeModifiers().isEmpty()) {
+    if (settings.attributeModifiers() == null || settings.attributeModifiers().isEmpty()) {
       return Config.getAttributeBonuses();
     }
     return settings.attributeModifiers();


### PR DESCRIPTION
Adds the set command, which directly sets the level of mobs. Very useful to add this command onto an item to set the world's level.
Also fixes a bug where upon loading into a world, you instantly crash by adding a null check. Calling .sEmpty() on a null map causes this crash.